### PR TITLE
ci: configura opções de publicação do GH Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -53,7 +53,7 @@ jobs:
         run: dotnet build -c ${{env.BUILD_CONFIGURATION}} --no-restore
 
       - name: Publish .NET
-        run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo
+        run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo -p GHPages=true
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet build --configuration ${{env.BUILD_CONFIGURATION}} --no-restore
 
       - name: Publish .NET
-        run: dotnet publish --configuration ${{env.BUILD_CONFIGURATION}} --output ${{env.GITHUB_PAGES_PATH}} --nologo
+        run: dotnet publish ${{env.PROJECT_PATH}} --configuration ${{env.BUILD_CONFIGURATION}} --output ${{env.GITHUB_PAGES_PATH}} --nologo
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,8 @@ name: Deploy BlazorWasm to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
     paths:
       - "!README.md"
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,10 +7,6 @@ on:
     paths:
       - "!README.md"
 
-  pull_request:
-    branches:
-      - main
-
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -50,10 +50,10 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration ${{env.BUILD_CONFIGURATION}} --no-restore
+        run: dotnet build -c ${{env.BUILD_CONFIGURATION}} --no-restore
 
       - name: Publish .NET
-        run: dotnet publish ${{env.PROJECT_PATH}} --configuration ${{env.BUILD_CONFIGURATION}} --output ${{env.GITHUB_PAGES_PATH}} --nologo
+        run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "!README.md"
 
+  pull_request:
+    branches:
+      - main
+
   workflow_dispatch:
 
 env:

--- a/src/IMC/IMC.csproj
+++ b/src/IMC/IMC.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.4" PrivateAssets="all" />
+    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Através do pacote `PublishSPAforGitHubPages.Build` são criados arquivos necessários para que o GitHub Pages entenda mais facilmente um aplicativo Blazor.