### PR TITLE
ci: altera meta tag base

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet build -c ${{env.BUILD_CONFIGURATION}} --no-restore
 
       - name: Publish .NET
-        run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo -p GHPages=true
+        run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -49,7 +49,11 @@ jobs:
         run: dotnet publish ${{env.PROJECT_PATH}} -c ${{env.BUILD_CONFIGURATION}} -o ${{env.GITHUB_PAGES_PATH}} --nologo
 
       - name: Setup Pages
+        id: setup
         uses: actions/configure-pages@v4
+
+      - name: Change base tag in index.html to ${{ steps.setup.outputs.base_url }}
+        run: sed -i 's/<base href="\/" \/>/<base href="\/${{ steps.setup.outputs.base_url }}\/" \/>/g' ${{env.GITHUB_PAGES_PATH}}/wwwroot/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/src/IMC/IMC.csproj
+++ b/src/IMC/IMC.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.4" PrivateAssets="all" />
-    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A meta tag base é alterada levando-se em conta o parâmetro de saída `base_url` da `actions/configure-pages`